### PR TITLE
Add catkin_include_dirs to CMakeLists.

### DIFF
--- a/pr_hardware_interfaces/CMakeLists.txt
+++ b/pr_hardware_interfaces/CMakeLists.txt
@@ -10,6 +10,9 @@ catkin_package(
 )
 
 include_directories(include)
+include_directories(SYSTEM
+  ${catkin_INCLUDE_DIRS}
+)
 
 add_library(${PROJECT_NAME}
   src/PositionCommandInterface.cpp
@@ -18,6 +21,10 @@ add_library(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
+)
+
+add_definitions(
+  ${catkin_DEFINITIONS}
 )
 
 install(DIRECTORY include/${PROJECT_NAME}/

--- a/pr_hardware_interfaces/package.xml
+++ b/pr_hardware_interfaces/package.xml
@@ -3,14 +3,11 @@
   <name>pr_hardware_interfaces</name>
   <version>0.0.0</version>
   <description>The pr_hardware_interfaces package</description>
-
-  <maintainer email="cliddick@cmu.edu">Clint Liddick</maintainer>
-
+  <maintainer email="gilwoo@cs.uw.edu">Gilwoo Lee</maintainer>
   <license>BSD</license>
   <author email="cliddick@cmu.edu">Clint Liddick</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-
   <depend>hardware_interface</depend>
 
   <export>


### PR DESCRIPTION
This change was necessary to make this compile without `hardware_interface` header error.