### PR TITLE
Add JointModeController

### DIFF
--- a/position_command_controller/CMakeLists.txt
+++ b/position_command_controller/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.3)
-project(position_command_controller)
+cmake_minimum_required(VERSION 3.0.0)
+project(position_command_controller VERSION 0.0.0)
 
 find_package(catkin
   REQUIRED COMPONENTS

--- a/pr_ros_controllers/CMakeLists.txt
+++ b/pr_ros_controllers/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.3)
-project(pr_ros_controllers)
+cmake_minimum_required(VERSION 3.0.0)
+project(pr_ros_controllers VERSION 0.0.0)
 
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS 

--- a/pr_ros_controllers/CMakeLists.txt
+++ b/pr_ros_controllers/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(${PROJECT_NAME}
   src/joint_group_position_controller.cpp
   src/joint_group_velocity_controller.cpp
   src/joint_group_effort_controller.cpp
+  src/joint_mode_controller.cpp
 )
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}

--- a/pr_ros_controllers/include/pr_ros_controllers/joint_mode_controller.h
+++ b/pr_ros_controllers/include/pr_ros_controllers/joint_mode_controller.h
@@ -1,0 +1,123 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Personal Robotics Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/// \author Ethan Kroll Gordon
+
+#pragma once
+
+
+#include <vector>
+#include <string>
+
+#include <ros/node_handle.h>
+#include <realtime_tools/realtime_buffer.h>
+
+// actionlib
+#include <actionlib/server/action_server.h>
+
+// ROS messages
+#include <pr_control_msgs/JointGroupCommandAction.h>
+#include <trajectory_msgs/JointTrajectoryPoint.h>
+#include <std_msgs/Float64MultiArray.h>
+
+// ros_controls
+#include <realtime_tools/realtime_server_goal_handle.h>
+#include <hardware_interface/joint_command_interface.h>
+#include <controller_interface/multi_interface_controller.h>
+#include <hardware_interface/joint_mode_interface.h>
+
+
+namespace joint_mode_controller
+{
+
+/**
+ * \brief Joint mode controller for a set of joints.
+ *
+ * This class provides an actionlib interface the control mode of the provided joints.
+ *
+ *
+ * \section ROS interface
+ *
+ * \param joints Names of the joints to control.
+ *
+ */
+
+class JointModeController: public controller_interface::Controller<hardware_interface::JointModeInterface>
+{
+public:
+  JointModeController() : controller_interface::Controller<hardware_interface::JointModeInterface>() {}
+  ~JointModeController() {}
+
+  bool init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle &n);
+
+  void starting(const ros::Time& /*time*/) { /* Do Nothing */}
+  void stopping(const ros::Time& /*time*/) { /* Do Nothing */}
+  void update(const ros::Time& /*time*/, const ros::Duration& /*period*/)
+  {
+    // Do Nothing
+  }
+
+protected:
+  typedef actionlib::ActionServer<pr_control_msgs::JointModeCommandAction>                    ActionServer;
+  typedef std::shared_ptr<ActionServer>                                                       ActionServerPtr;
+  typedef ActionServer::GoalHandle                                                            GoalHandle;
+
+  realtime_tools::RealtimeBuffer<std::vector<double> > commands_buffer_;
+  std::vector<double> default_commands_; // Defaults to 0 on init, can override in starting()
+  unsigned int n_joints_;
+
+  std::vector< std::string >                     joint_names_;         ///< Controlled joint names.
+  std::vector< hardware_interface::JointHandle > joints_;              ///< Handle to controlled joint.
+  std::string                                    name_;               ///< Controller name.
+  RealtimeGoalHandlePtr                          rt_active_goal_;     ///< Currently active action goal, if any.
+
+  // ROS API
+  ros::NodeHandle    controller_nh_;
+  ActionServerPtr    action_server_;
+  ros::Timer         goal_handle_timer_;
+  ros::Duration      action_monitor_period_;
+
+  std::shared_ptr<hardware_interface::JointModeHandle> mode_handle_;
+
+  // Callback, immediately will 
+  void goalCB(GoalHandle gh);
+
+  // General callbacks
+  void cancelCB(GoalHandle gh) { /* Do Nothing */ }
+
+};
+
+} // namespace
+
+#include <pr_ros_controllers/detail/forward_joint_group_command_controller_impl.h>

--- a/pr_ros_controllers/include/pr_ros_controllers/joint_mode_controller.h
+++ b/pr_ros_controllers/include/pr_ros_controllers/joint_mode_controller.h
@@ -113,7 +113,7 @@ protected:
   void goalCB(GoalHandle gh);
 
   // General callbacks
-  void cancelCB(GoalHandle gh) { /* Do Nothing */ }
+  void cancelCB(GoalHandle gh) { gh.setCanceled(); }
 
 };
 

--- a/pr_ros_controllers/plugins.xml
+++ b/pr_ros_controllers/plugins.xml
@@ -24,5 +24,13 @@
     </description>
   </class>
 
+  <class name="pr_ros_controllers/JointModeController"
+      type="pr_ros_controllers::JointModeController"
+      base_class_type="controller_interface::ControllerBase">
+    <description>
+      The JointModeController sets the underlying RobotHW's Joint Command Mode. It expects a JointModeInterface.
+    </description>
+  </class>
+
 </library>
 

--- a/pr_ros_controllers/src/joint_mode_controller.cpp
+++ b/pr_ros_controllers/src/joint_mode_controller.cpp
@@ -1,0 +1,120 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Personal Robotics Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/// \author Ethan Kroll Gordon
+
+#include <pr_ros_controllers/joint_mode_controller.h>
+#include <pluginlib/class_list_macros.hpp>
+
+bool ForwardJointGroupCommandController<HardwareInterface>::init(hardware_interface::JointModeInterface* jmi,
+                                                                    ros::NodeHandle&   n)
+{
+    // Get Joint 
+    if(jmt && n.getParam("mode_handle", handle_name)) {
+      ROS_DEBUG_STREAM_NAMED(name_, "Enabling joint mode handling.");
+      mode_handle_.reset(new hardware_interface::JointModeHandle(jmt->getHandle(handle_name)));
+    }
+
+    // Cache controller node handle
+    controller_nh_ = n;
+
+    // Controller name
+    name_ = internal::getLeafNamespace(controller_nh_);
+
+    // Action status checking update rate
+    double action_monitor_rate = 20.0;
+    controller_nh_.getParam("action_monitor_rate", action_monitor_rate);
+    action_monitor_period_ = ros::Duration(1.0 / action_monitor_rate);
+    ROS_DEBUG_STREAM_NAMED(name_, "Action status changes will be monitored at " << action_monitor_rate << "Hz.");
+
+    // Initialize controlled joints
+    std::string param_name = "joints";
+    if(!n.getParam(param_name, joint_names_))
+    {
+      ROS_ERROR_STREAM("Failed to getParam '" << param_name << "' (namespace: " << n.getNamespace() << ").");
+      return false;
+    }
+    n_joints_ = joint_names_.size();
+
+    if(n_joints_ == 0){
+      ROS_ERROR_STREAM("List of joint names is empty.");
+      return false;
+    }
+    
+    // Clear joints_ first in case this is called twice
+    joints_.clear();
+    for(unsigned int i=0; i<n_joints_; i++)
+    {
+      try
+      {
+        joints_.push_back(hw->getHandle(joint_names_[i]));
+      }
+      catch (const hardware_interface::HardwareInterfaceException& e)
+      {
+        ROS_ERROR_STREAM("Exception thrown: " << e.what());
+        return false;
+      }
+    }
+
+    commands_buffer_.writeFromNonRT(std::vector<double>(n_joints_, 0.0));
+    default_commands_.resize(n_joints_);
+
+    // ROS API: Subscribed topics
+    sub_command_ = n.subscribe<std_msgs::Float64MultiArray>("command", 1, &ForwardJointGroupCommandController::commandCB, this);
+
+    // ROS API: Action interface
+    action_server_.reset(new ActionServer(controller_nh_, "joint_group_command",
+                                        boost::bind(&ForwardJointGroupCommandController::goalCB,   this, _1),
+                                        boost::bind(&ForwardJointGroupCommandController::cancelCB, this, _1),
+                                        false));
+    action_server_->start();
+
+    // Add Joint Mode switching if handle provided
+    hardware_interface::JointModeInterface* jmt = robot_hw->get<hardware_interface::JointModeInterface>();
+    std::string handle_name;
+    if(jmt && n.getParam("mode_handle", handle_name)) {
+      ROS_DEBUG_STREAM_NAMED(name_, "Enabling joint mode handling.");
+      mode_handle_.reset(new hardware_interface::JointModeHandle(jmt->getHandle(handle_name)));
+    }
+    return true;
+}
+
+template <class T>
+void forward_command_controller::ForwardJointGroupCommandController<T>::goalCB(GoalHandle gh)
+{
+  // Set as position command
+  setGoal(gh, gh.getGoal()->command.velocities);
+}
+
+PLUGINLIB_EXPORT_CLASS(pr_ros_controllers::JointModeController,controller_interface::ControllerBase)

--- a/trigger_controller/CMakeLists.txt
+++ b/trigger_controller/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.3)
-project(trigger_controller)
+cmake_minimum_required(VERSION 3.0.0)
+project(trigger_controller VERSION 0.0.0)
 
 find_package(catkin
   REQUIRED COMPONENTS


### PR DESCRIPTION
Simple controller that commands the JointModeInterface of a robot and exposes a JointModeCommandAction.

Prerequisite: https://github.com/personalrobotics/pr_control_msgs/pull/5

Tested on Gen3 switching the single JointModeInterface "joint_mode" between VELOCITY and POSITION.